### PR TITLE
Add console line erasing functions and Windows support

### DIFF
--- a/include/erase.hpp
+++ b/include/erase.hpp
@@ -155,6 +155,32 @@ namespace console {
         FillConsoleOutputAttribute(hConsole, csbi.wAttributes, cellsToClear, startCoord, &charsWritten);
         SetConsoleCursorPosition(hConsole, csbi.dwCursorPosition);
     }
+
+    /**
+     * @brief Erases the line the cursor is currently on
+     */
+    void eraseCurrentLine() {
+        if (isANSIEnabled()) {
+            std::cout << "\033[2K";
+            return;
+        }
+        HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (hConsole == INVALID_HANDLE_VALUE) {
+            std::cerr << "Error: Unable to get console handle." << std::endl;
+            return;
+        }
+        CONSOLE_SCREEN_BUFFER_INFO csbi;
+        if (!GetConsoleScreenBufferInfo(hConsole, &csbi)) {
+            std::cerr << "Error: Unable to get console screen buffer info." << std::endl;
+            return;
+        }
+        DWORD cellsToClear = csbi.dwSize.X;
+        DWORD charsWritten;
+        COORD startCoord = {0, csbi.dwCursorPosition.Y};
+        FillConsoleOutputCharacter(hConsole, ' ', cellsToClear, startCoord, &charsWritten);
+        FillConsoleOutputAttribute(hConsole, csbi.wAttributes, cellsToClear, startCoord, &charsWritten);
+        SetConsoleCursorPosition(hConsole, csbi.dwCursorPosition);
+    }
 }
 
 #endif

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -36,6 +36,6 @@ int main() {
     console::println();
     console::print("BOL Testing");
     console::moveCursorLeft(3);
-    console::eraseFromCursorToBOL();
+    console::eraseCurrentLine();
     return 0;
 }


### PR DESCRIPTION
Introduce functions to erase from the cursor to the end of line, from the cursor to the beginning of line, and to erase the current line. Implement Windows support for these functionalities and enhance testing with print and cursor movement features.